### PR TITLE
Hotfix ssid

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ sudo chmod 755 /etc/NetworkManager/dispatcher.d/wlan_auto_toggle.sh
 Оформление `BSSID_CONNECT`:  
   * только CapsLock; 
   * BSSID указываются через пробел;
-  * SSID не должен содержать пробелы и другие спец символы.
+  * SSID может содержать пробелы, но не другие спец символы.
 ```bash
 BSSID_CONNECT=('11:AA:11:AA:11:A1' '11:AA:11:AA:11:A2' '11:AA:11:AA:11:A3')
-SSID_CONNECT=('WIFI_name_1' 'WIFI-name_2')
+SSID_CONNECT=('WIFI_name_1' 'WIFI-name_2' 'WIFI name 3')
 ```
 3. Перезапустить NetworkManager:
 ```bash

--- a/wlan_auto_toggle.sh
+++ b/wlan_auto_toggle.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
 # Отключаем соединение от wifi, при условии, что BSSID не соответствует разрешенному.
-# BSSID_CONNECT вводить только в верхнем регистре BSSID_CONNECT=('12:CE:87:FB:94:08' 'CE:87:FB:94:08')
-# SSID_CONNECT рекомендации по названию, не использовать в названии сети пробелы, специальные символы
+# BSSID_CONNECT: вводить только в верхнем регистре BSSID_CONNECT=('12:CE:87:FB:94:08' 'CE:87:FB:94:08')
+# SSID_CONNECT: допускается использовать пробелы, но не специальные символы
 #
 #
 # Используйте команду 
 # nmcli -f ACTIVE,BSSID,SSID dev wifi
 # чтобы узнать BSSID,SSID
-# Название сети не должно содержать пробелов и других сисмволов.
+
 
 BSSID_CONNECT=('11:AA:11:AA:11:A1' '11:AA:11:AA:11:A2' '11:AA:11:AA:11:A3')
-SSID_CONNECT=('WIFI_name_1' 'WIFI-name_2')
+SSID_CONNECT=('WIFI_name_1' 'WIFI-name_2' 'WIFI name 3')
 
 interface=$1
 status=$2
 
 disconnect_wifi(){
-    bssid_ssid_active=$(nmcli -f ACTIVE,BSSID,SSID dev wifi | grep "yes" | awk '{print$2,$3}'| head -n1)
+    bssid_ssid_active=$(nmcli -f ACTIVE,BSSID,SSID dev wifi | grep "yes" | awk '{ for(i=2; i<=NF; ++i) printf $i""FS; print "" }' | head -n1)
     bssid_ssid=( $(printf "$bssid_ssid_active") )
     
-    if [[ " ${BSSID_CONNECT[*]} " == *"${bssid_ssid[0]}"* && " ${SSID_CONNECT[*]} " == *"${bssid_ssid[1]}"* ]];then
+    if [[ " ${BSSID_CONNECT[*]} " == *"${bssid_ssid[0]}"* && " ${SSID_CONNECT[*]} " == *" ${bssid_ssid[*]:1} "* ]];then
       echo "Подключено" > /dev/null
     else
         nmcli connection down "$CONNECTION_UUID"


### PR DESCRIPTION
Исправлена ошибка при подключении по SSID. Раньше скрипт подключался к сети в имени которой, присутствовали одинаковые начальные названия. Добавлена возможность скрипта учитывать пробелы в имени сети.